### PR TITLE
Mobile site polish and animation audit

### DIFF
--- a/templates/jewish-mothers-deli/full-site/src/components/AlternatingMenuSection.tsx
+++ b/templates/jewish-mothers-deli/full-site/src/components/AlternatingMenuSection.tsx
@@ -6,7 +6,6 @@ import {
   VStack,
   HStack,
   Text,
-  Badge,
   useBreakpointValue,
 } from '@chakra-ui/react'
 import { MenuCategory } from '../data/menuData'

--- a/templates/jewish-mothers-deli/full-site/src/components/Navbar.tsx
+++ b/templates/jewish-mothers-deli/full-site/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import {
   Box,
   Button,
@@ -6,9 +6,9 @@ import {
   HStack,
   VStack,
   useDisclosure,
-  Collapse,
   Flex,
   IconButton,
+  Portal,
 } from '@chakra-ui/react'
 import { Link, useLocation } from 'react-router-dom'
 import { HamburgerIcon, CloseIcon } from '@chakra-ui/icons'
@@ -24,6 +24,10 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
   const location = useLocation()
   const isMobile = useBreakpointValue({ base: true, md: false })
   const [internalIsScrolled, setInternalIsScrolled] = useState(false)
+  const [shouldRenderMenu, setShouldRenderMenu] = useState(false)
+  const overlayRef = useRef<HTMLDivElement | null>(null)
+  const firstNavButtonRef = useRef<HTMLButtonElement | null>(null)
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null)
 
   // Optimized scroll handler with throttling instead of debouncing for better performance
   const handleScroll = useCallback(() => {
@@ -53,21 +57,86 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
     return () => window.removeEventListener('scroll', throttledScrollHandler)
   }, [throttledScrollHandler])
 
+  // Manage mounting for smooth exit animation
+  useEffect(() => {
+    if (isOpen) {
+      setShouldRenderMenu(true)
+    } else {
+      const timeoutId = window.setTimeout(() => setShouldRenderMenu(false), 200)
+      return () => window.clearTimeout(timeoutId)
+    }
+  }, [isOpen])
+
   // Close mobile menu when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (isMobile && isOpen) {
-        const target = event.target as Element
-        const navbar = document.querySelector('[data-navbar]')
-        if (navbar && !navbar.contains(target)) {
-          onToggle()
-        }
+      if (!(isMobile && isOpen)) return
+      const target = event.target as Element
+      // If click is inside the overlay menu, do nothing
+      if (overlayRef.current && overlayRef.current.contains(target)) return
+      const navbar = document.querySelector('[data-navbar]')
+      if (navbar && !navbar.contains(target)) {
+        onToggle()
       }
     }
 
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [isMobile, isOpen, onToggle])
+
+  // Body scroll lock when mobile menu is open
+  useEffect(() => {
+    if (!isMobile) return
+    const body = document.body
+    const html = document.documentElement
+    const previousBodyOverflow = body.style.overflow
+    const previousHtmlOverflow = html.style.overflow
+    if (isOpen) {
+      body.style.overflow = 'hidden'
+      html.style.overflow = 'hidden'
+    }
+    return () => {
+      body.style.overflow = previousBodyOverflow
+      html.style.overflow = previousHtmlOverflow
+    }
+  }, [isMobile, isOpen])
+
+  // Minimal focus trap and ESC to close when menu is open
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onToggle()
+        // Return focus to the menu button
+        window.setTimeout(() => menuButtonRef.current?.focus(), 0)
+        return
+      }
+      if (event.key === 'Tab' && overlayRef.current) {
+        const focusable = overlayRef.current.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex="0"]'
+        )
+        if (!focusable.length) return
+        const focusables = Array.from(focusable)
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        if (event.shiftKey) {
+          if (document.activeElement === first) {
+            event.preventDefault()
+            last.focus()
+          }
+        } else {
+          if (document.activeElement === last) {
+            event.preventDefault()
+            first.focus()
+          }
+        }
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    // Move focus to first nav button when opening
+    window.setTimeout(() => firstNavButtonRef.current?.focus(), 0)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onToggle])
 
   // Use internal scroll detection if no prop is provided, otherwise use prop
   const isScrolled = propIsScrolled !== undefined ? propIsScrolled : internalIsScrolled
@@ -99,6 +168,10 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
           behavior: 'smooth'
         })
       }, 100)
+    }
+    // Close the mobile menu on navigation
+    if (isMobile && isOpen) {
+      onToggle()
     }
   }, [location.pathname])
 
@@ -256,6 +329,7 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
             {/* Hamburger Menu */}
             <Box position="absolute" top={isOpen ? "56px" : (shrinkLogo ? "2.5" : "56px")} left={4} zIndex={10003} transform={isOpen ? "translateY(-50%)" : (shrinkLogo ? "none" : "translateY(-50%)")} transition="all 0.3s ease">
               <IconButton
+                ref={menuButtonRef}
                 aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
                 icon={isOpen ? <CloseIcon /> : <HamburgerIcon />}
                 onClick={onToggle}
@@ -282,12 +356,12 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
               />
             </Box>
 
-            {/* Mobile Logo */}
-            {!isOpen && !shrinkLogo && (
+            {/* Mobile Logo - always visible when menu is closed (also when shrinkLogo) */}
+            {!isOpen && (
               <Box 
                 position="absolute" 
                 left="50%" 
-                top="70%"
+                top={shrinkLogo ? '55%' : '70%'}
                 transform="translate(-50%, -50%)"
                 zIndex={5}
                 transition="all 0.3s ease"
@@ -410,61 +484,97 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
 
       </Box>
 
-      {/* Mobile Navigation */}
-      {isMobile && (
-        <Collapse in={isOpen} animateOpacity>
+      {/* Mobile Navigation - full-screen overlay using Portal for clean stacking and transforms */}
+      {isMobile && shouldRenderMenu && (
+        <Portal>
           <Box
-            bg="linear-gradient(135deg, #fbe7cc 0%, #f5ddb8 50%, #ead5a3 100%)"
+            ref={overlayRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Mobile navigation"
             position="fixed"
-            top={isOpen ? "140px" : (shrinkLogo ? "100px" : "120px")}
-            left="0"
-            right="0"
-            zIndex={9999}
-            minH="100vh"
+            top={0}
+            left={0}
+            right={0}
+            bottom={0}
+            zIndex={10000}
+            bg="linear-gradient(135deg, #fbe7cc 0%, #f5ddb8 50%, #ead5a3 100%)"
+            sx={{
+              '@keyframes menuSlideIn': {
+                from: { opacity: 0, transform: 'translateY(-8px) translateZ(0)' },
+                to: { opacity: 1, transform: 'translateY(0) translateZ(0)' },
+              },
+              '@keyframes menuSlideOut': {
+                from: { opacity: 1, transform: 'translateY(0) translateZ(0)' },
+                to: { opacity: 0, transform: 'translateY(-8px) translateZ(0)' },
+              },
+              animation: `${isOpen ? 'menuSlideIn' : 'menuSlideOut'} 200ms cubic-bezier(0.4, 0, 0.2, 1)`,
+              willChange: 'transform, opacity',
+            }}
           >
             {/* Background Pattern */}
             <Box
               position="absolute"
-              top="0"
-              left="0"
-              right="0"
-              bottom="0"
+              inset={0}
               opacity="0.03"
               backgroundImage="radial-gradient(circle at 25% 25%, #8a542e 2px, transparent 2px), radial-gradient(circle at 75% 75%, #6f3e13 2px, transparent 2px)"
               backgroundSize="60px 60px"
               pointerEvents="none"
             />
-            
+
+            {/* Overlay header with centered logo and close button */}
+            <Box position="relative" h="140px" zIndex={1}>
+              <Box
+                position="absolute"
+                insetX={0}
+                top={0}
+                h="140px"
+                bg="linear-gradient(135deg, #fbe7cc 0%, #f5ddb8 50%, #ead5a3 100%)"
+              />
+              <Box position="absolute" inset={0} display="flex" alignItems="center" justifyContent="center">
+                <Link to="/" onClick={() => handleNavigation('/')}> 
+                  {logoImage}
+                </Link>
+              </Box>
+              <IconButton
+                aria-label="Close navigation menu"
+                icon={<CloseIcon />}
+                onClick={onToggle}
+                variant="ghost"
+                color={'brand.darkBrown'}
+                bg="transparent"
+                position="absolute"
+                top="56px"
+                left={4}
+                zIndex={2}
+                border={'none'}
+                size="lg"
+                fontSize="24px"
+                transition="all 0.2s ease"
+                borderRadius="md"
+                _active={{ transform: 'scale(0.95)' }}
+              />
+            </Box>
+
+            {/* Menu body */}
             <VStack 
-              spacing={8} 
-              pt="40px" 
+              spacing={8}
+              pt="10px"
               pb="40px"
               px="20px"
-              align="center" 
-              justify="flex-start" 
+              align="center"
+              justify="flex-start"
               minH="calc(100vh - 140px)"
               position="relative"
-              zIndex="1"
+              zIndex={1}
             >
-              {/* Centered Logo in mobile menu */}
-              <Box mb={4}>
-                <img
-                  src="/JMD_full_logo.png"
-                  alt="Jewish Mother's Deli Logo"
-                  style={{
-                    maxHeight: '120px',
-                    height: 'auto',
-                    width: 'auto',
-                    objectFit: 'contain',
-                  }}
-                />
-              </Box>
               {/* Navigation Links */}
               <VStack spacing={4} mb="8">
-                {navItems.map((item) => (
+                {navItems.map((item, index) => (
                   <Box key={item.name}>
                     <Link to={item.path} onClick={() => handleNavigation(item.path)}>
                       <Button
+                        ref={index === 0 ? firstNavButtonRef : undefined}
                         variant="ghost"
                         color={isActivePage(item.path) ? 'brand.mediumBrown' : 'brand.darkBrown'}
                         _hover={{
@@ -482,9 +592,7 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
                         textTransform="uppercase"
                         letterSpacing="0.5px"
                         transition="all 0.3s ease"
-                        _active={{
-                          transform: "scale(0.95)",
-                        }}
+                        _active={{ transform: 'scale(0.95)' }}
                       >
                         {item.name}
                       </Button>
@@ -505,8 +613,7 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
                   letterSpacing="0.8px"
                   py="6"
                   onClick={() => {
-                    // Add order functionality here
-                    window.open('tel:+17575551234', '_self');
+                    window.open('tel:+17575551234', '_self')
                   }}
                 >
                   ORDER NOW
@@ -523,12 +630,9 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
                   py="6"
                   borderColor="brand.mediumBrown"
                   color="brand.mediumBrown"
-                  _hover={{
-                    bg: 'brand.mediumBrown',
-                    color: 'white',
-                  }}
+                  _hover={{ bg: 'brand.mediumBrown', color: 'white' }}
                   onClick={() => {
-                    window.open('https://maps.google.com/?q=Jewish+Mother\'s+Deli+Williamsburg+VA', '_blank');
+                    window.open('https://maps.google.com/?q=Jewish+Mother\'s+Deli+Williamsburg+VA', '_blank')
                   }}
                 >
                   GET DIRECTIONS
@@ -543,29 +647,22 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
                   fontSize="1.2rem"
                   fontWeight="600"
                   color="brand.darkBrown"
-                  _hover={{
-                    color: 'brand.mediumBrown',
-                  }}
+                  _hover={{ color: 'brand.mediumBrown' }}
                   onClick={() => {
-                    window.open('tel:+17575551234', '_self');
+                    window.open('tel:+17575551234', '_self')
                   }}
                 >
                   <span style={{ fontFamily: 'Dancing Script, cursive', fontSize: '1.3rem' }}>
                     A Modern Jewish Kitchen Deli
                   </span>
                 </Button>
-                <Box
-                  fontSize="sm"
-                  color="brand.lightBrown"
-                  textAlign="center"
-                  fontStyle="italic"
-                >
+                <Box fontSize="sm" color="brand.lightBrown" textAlign="center" fontStyle="italic">
                   Tap to call
                 </Box>
               </VStack>
             </VStack>
           </Box>
-        </Collapse>
+        </Portal>
       )}
     </Box>
   )

--- a/templates/jewish-mothers-deli/full-site/src/pages/CuisinePage.tsx
+++ b/templates/jewish-mothers-deli/full-site/src/pages/CuisinePage.tsx
@@ -268,8 +268,8 @@ const CuisinePage: React.FC = () => {
         {/* Sticky Category Navigation - Outside Container for better positioning */}
         <Box
           position="sticky"
-          top={{ base: "60px", md: "100px", lg: "95px" }}
-          zIndex={5000}
+          top={{ base: "140px", md: "120px", lg: "95px" }}
+          zIndex={1200}
           pointerEvents="auto"
           bg="brand.mediumBrown"
           py={4}


### PR DESCRIPTION
Refactor mobile navigation to use a Portal overlay for smooth, jank-free animations and ensure logo visibility in both the mobile menu and sticky header.

The previous mobile menu implementation using Chakra's `Collapse` component caused layout shifts and z-index conflicts, leading to a "janky" user experience. This PR replaces it with a `Portal`-based full-screen overlay, leveraging CSS transforms for smooth animations, locking body scroll, and adding basic accessibility features like focus trapping and ESC to close. This ensures the logo is consistently visible in the sticky header and within the mobile menu, and resolves z-index issues with other sticky elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-0937a7a9-8191-4279-bc36-800bf840b59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0937a7a9-8191-4279-bc36-800bf840b59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the mobile menu with a Portal-based full-screen overlay for smooth, jank-free animations and stable z-index. Adds scroll lock and accessibility, ensures the logo stays visible, and adjusts the CuisinePage sticky nav to sit under the overlay.

- **New Features**
  - Full-screen overlay with CSS transform animations.
  - Body scroll lock, focus trap, ESC to close, and focus return to the menu button.
  - Closes on route change and keeps a centered logo in the overlay header.

<!-- End of auto-generated description by cubic. -->

