### PR TITLE
Fix header logo placement

### DIFF
--- a/templates/jewish-mothers-deli/full-site/src/components/Navbar.tsx
+++ b/templates/jewish-mothers-deli/full-site/src/components/Navbar.tsx
@@ -188,7 +188,8 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
     
     // Mobile logo sizing
     if (isMobile) {
-      maxHeight = '160px'; // reduce to avoid cramped look
+      // Slightly smaller on mobile to avoid overflow/clipping
+      maxHeight = '150px';
       if (shrinkLogo) {
         maxHeight = '120px';
         baseScale = 0.8;
@@ -274,7 +275,8 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
         maxW="1400px"
         mx="auto"
         position="relative"
-        minH={{ base: '130px', md: '180px', lg: '240px' }}
+        // Provide enough vertical space so the logo never clips
+        minH={{ base: '160px', md: '180px', lg: '240px' }}
         zIndex={2}
       >
         {/* Mobile Layout */}
@@ -361,7 +363,8 @@ const Navbar: React.FC<NavbarProps> = ({ isScrolled: propIsScrolled, shrinkLogo 
               <Box 
                 position="absolute" 
                 left="50%" 
-                top={shrinkLogo ? '55%' : '70%'}
+                // Center the logo better on mobile to prevent bottom clipping
+                top={shrinkLogo ? '55%' : '58%'}
                 transform="translate(-50%, -50%)"
                 zIndex={5}
                 transition="all 0.3s ease"


### PR DESCRIPTION
Adjust mobile navbar logo sizing and positioning to prevent it from being cut off.

---
<a href="https://cursor.com/background-agent?bcId=bc-60a59dd6-007d-4321-8333-bf6033775099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-60a59dd6-007d-4321-8333-bf6033775099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes mobile header logo clipping by resizing the logo, increasing navbar height, and fine-tuning positioning. The logo now stays fully visible and centered on small screens.

- **Bug Fixes**
  - Reduced mobile logo maxHeight to 150px.
  - Increased navbar base minH to 160px.
  - Adjusted mobile logo top to 58% (non-shrink) to prevent bottom clipping.

<!-- End of auto-generated description by cubic. -->

